### PR TITLE
V1 3 0

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+exclude_paths:
+  - "**/*.md"
+  - "attic/**"
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Visitor
 
 ![Sonatype Central](https://maven-badges.sml.io/sonatype-central/com.phasmidsoftware/visitor_3/badge.svg?color=blue)
@@ -15,14 +14,14 @@ A purely functional, typeclass-driven graph and tree traversal library for Scala
 ## Core Idea
 
 The central design principle is a strict separation of concerns.
-Traversal algorithms (BFS, DFS, best-first) know nothing about the domain — they only know that a data structure has neighbours.
+Traversal algorithms (BFS, DFS, best-first, Dijkstra-style weighted traversal) know nothing about the domain — they only know that a data structure has neighbours.
 Everything derived from visiting a node is captured in a `Visitor`, which accumulates results immutably into a `Journal`.
 
 This is achieved entirely through typeclasses rather than inheritance hierarchies, making the library highly composable and easy to extend.
 
 ## Architecture
 
-The library is built from five orthogonal typeclasses:
+The library is built from six orthogonal typeclasses:
 
 ### `Evaluable[V, R]`
 
@@ -63,6 +62,15 @@ trait VisitedSet[V]:
 Immutable and purely functional.
 A default `given` instance backed by an immutable `Set` is provided automatically.
 
+For weighted traversals where the frontier holds `(cost, vertex)` tuples, a
+`TupleVisitedSet[E, V]` is also provided. It tracks visited-ness on the vertex
+component `V` alone — stale `(higherCost, v)` frontier entries are correctly
+recognised as already visited:
+
+```scala
+given [E, V]: VisitedSet[(E, V)] = TupleVisitedSet(Set.empty[V])
+```
+
 ### `Frontier[F[_]]`
 
 Answers: *in what order do we explore?*
@@ -76,13 +84,43 @@ trait Frontier[F[_]]:
 ```
 
 This is the key to getting BFS, DFS, and best-first traversal from a single algorithm.
-Three `given` instances are provided:
+Four `given` instances are provided:
 
 | Instance | Type | Traversal order |
 |---|---|---|
 | `Frontier[Queue]` | FIFO queue | Breadth-first (BFS) |
 | `Frontier[Stack]` | LIFO stack (as `List`) | Depth-first (DFS) |
-| `Frontier[PrioQueue]` | Binary min-heap | Best-first / Dijkstra-style |
+| `Frontier[PrioQueue]` | Indexed binary min-heap | Best-first (duplicates permitted) |
+| `Frontier[IndexedPrioQueue]` | Indexed binary min-heap | Best-first with `decreaseKey` (no duplicates) |
+
+### `CostUpdate[W, F[_]]`
+
+Answers: *does any frontier entry need its priority updated after a node is settled?*
+
+```scala
+trait CostUpdate[W, F[_]]:
+  def update(frontier: F[W], w: W): F[W]
+```
+
+A default no-op `given` is provided, resolved automatically for DFS and BFS.
+For Dijkstra and Prim, the consuming library provides a `given CostUpdate[W, IndexedPrioQueue]`
+that calls `decreaseKey` whenever a cheaper path to a frontier vertex is found.
+This keeps all domain knowledge out of `Traversal` itself.
+
+### `Monoid[A]`
+
+Answers: *what is the identity cost, and how do costs combine?*
+
+```scala
+trait Monoid[A]:
+  def identity: A
+  def combine(x: A, y: A): A
+```
+
+Mirrors the Cats `Monoid` typeclass without the Cats dependency.
+Used by weighted traversals (Dijkstra) to seed the frontier with the identity
+cost and accumulate costs along a path. `given` instances are provided for
+`Int`, `Long`, `Double`, and `Float`.
 
 ### `Visitor[V, R, J]`
 
@@ -97,25 +135,50 @@ trait Visitor[V, R, J <: Appendable[(V, Option[R])]]:
 
 The canonical implementation is `JournaledVisitor`, which appends `(node, Option[result])` pairs to a `Journal` on each visit.
 
+## Priority Queue Hierarchy
+
+Visitor provides a three-type priority queue hierarchy:
+
+- **`BinaryHeap[T]`** — pure data structure; array-based min-heap; `insert` and `removeMin` only; duplicates permitted.
+- **`PrioQueue[T]`** — ADT backed by `BinaryHeap`; captures `Ordering[T]` at construction; duplicates permitted; no index.
+- **`IndexedPrioQueue[T]`** — extends `PrioQueue` with a `Map[T, Int]` position index; enforces one-entry-per-key; adds `decreaseKey` and `contains`.
+
+`Ordering[T]` is captured at construction time in both `PrioQueue` and `IndexedPrioQueue`, so `Frontier[PrioQueue]` and `Frontier[IndexedPrioQueue]` remain fully polymorphic — no `Ordering` context is needed at `offer`/`take` call sites.
+
+Use `PrioQueue` for general best-first traversal. Use `IndexedPrioQueue` when you need `decreaseKey` — i.e. for Dijkstra and Prim via `bestFirstWeighted`.
+
 ## Traversal Engine
 
 `Traversal` is the single traversal engine.
-Its internal `loop` is a tail-recursive function that is shared across all traversal strategies — the only difference is the `Frontier` instance in scope.
+Its internal `loop` is a tail-recursive function shared across all traversal strategies.
 
 ```scala
 object Traversal:
-  def bfs[V, R, J <: Appendable[(V, Option[R])]](start: V, visitor: Visitor[V, R, J], goal: V => Boolean = _ => false)
+  def bfs[V, R, J](start: V, visitor: Visitor[V, R, J], goal: V => Boolean = _ => false)
       (using Neighbours[V, V], Evaluable[V, R], VisitedSet[V]): Visitor[V, R, J]
 
-  def dfs[V, R, J <: Appendable[(V, Option[R])]](start: V, visitor: Visitor[V, R, J])
+  def dfs[V, R, J](start: V, visitor: Visitor[V, R, J],
+                   order: DfsOrder = DfsOrder.Pre, goal: V => Boolean = _ => false)
       (using Neighbours[V, V], Evaluable[V, R], VisitedSet[V]): Visitor[V, R, J]
 
-  def bestFirst[V : Ordering, R, J <: Appendable[(V, Option[R])]](start: V, visitor: Visitor[V, R, J])
+  def bestFirst[V: Ordering, R, J](start: V, visitor: Visitor[V, R, J], goal: V => Boolean = _ => false)
       (using Neighbours[V, V], Evaluable[V, R], VisitedSet[V]): Visitor[V, R, J]
 
-  def traverseTree[H, V, R, J <: Appendable[(V, Option[R])], F[_]](start: H, visitor: Visitor[V, R, J])
-      (using Neighbours[H, V], Neighbours[V, V], Evaluable[V, R], VisitedSet[V], Frontier[F], F[V]): Visitor[V, R, J]
+  def bestFirstMax[V: Ordering, R, J](start: V, visitor: Visitor[V, R, J], goal: V => Boolean = _ => false)
+      (using Neighbours[V, V], Evaluable[V, R], VisitedSet[V]): Visitor[V, R, J]
+
+  def bestFirstWeighted[W: Ordering, R, J](start: W, visitor: Visitor[W, R, J], goal: W => Boolean = _ => false)
+      (using Neighbours[W, W], Evaluable[W, R], VisitedSet[W],
+             CostUpdate[W, IndexedPrioQueue], IndexedPrioQueue[W]): Visitor[W, R, J]
+
+  def traverseTree[H, V, R, J](start: H, visitor: Visitor[V, R, J],
+                                order: DfsOrder = DfsOrder.Pre, goal: V => Boolean = _ => false)
+      (using Neighbours[H, V], Neighbours[V, V], Evaluable[V, R], VisitedSet[V]): Visitor[V, R, J]
 ```
+
+`bestFirstWeighted` is the entry point for Dijkstra- and Prim-style traversals.
+The frontier element type `W` is typically `(E, V)` where `E` is the cost type.
+The caller supplies a `given CostUpdate[W, IndexedPrioQueue]` and `given IndexedPrioQueue[W]`.
 
 ## Journals
 
@@ -124,7 +187,9 @@ A `Journal` is an immutable, appendable log of visited results. Two implementati
 - `ListJournal[X]` — prepends elements; most recently visited node is at the head
 - `QueueJournal[X]` — enqueues elements; preserves visit order (FIFO)
 
-The `FunctionMapJournal` and `MapJournal` from the companion package also satisfy `Appendable` and can be used directly as journals.
+Note: `ListJournal` prepends, so post-order DFS results appear reversed. Use
+`QueueJournal` when visit order must be preserved, or reverse the `ListJournal`
+result after traversal.
 
 ## Usage Example
 
@@ -166,12 +231,38 @@ dfsPostResult.result.map(_._1).toList // nodes in DFS post-order (topological so
 goalResult.result.map(_._1).toList    // nodes visited up to and including node 4
 ```
 
+## Weighted Traversal Example
+
+For Dijkstra-style traversal, the frontier holds `(cost, vertex)` tuples.
+The consuming library provides `Neighbours[(E,V),(E,V)]` for cost accumulation
+and `CostUpdate[(E,V), IndexedPrioQueue]` for `decreaseKey`:
+
+```scala
+given Ordering[(Double, Int)] = Ordering.by(_._1)
+
+given Neighbours[(Double, Int), (Double, Int)] with
+  def neighbours(ev: (Double, Int)): Iterator[(Double, Int)] =
+    val accCost: Double = ev._1
+    val v: Int          = ev._2
+    // expand v's adjacencies, accumulating cost
+    adjacency(v).iterator.map(e => (accCost + e.weight, e.to))
+
+given CostUpdate[(Double, Int), IndexedPrioQueue] with
+  def update(frontier: IndexedPrioQueue[(Double, Int)], ev: (Double, Int)): IndexedPrioQueue[(Double, Int)] =
+    // call decreaseKey for any frontier entry whose cost has improved
+    ...
+
+given IndexedPrioQueue[(Double, Int)] = IndexedPrioQueue.empty[(Double, Int)]
+
+val visitor = JournaledVisitor.withQueueJournal[(Double, Int), MyEdge]
+val result  = Traversal.bestFirstWeighted((0.0, startVertex), visitor)
+```
+
 ## Goal Predicate
 
 All traversal methods accept an optional `goal: V => Boolean` parameter for early termination:
 
 ```scala
-// Stop as soon as node 4 is reached
 val result = Traversal.bfs(start, visitor, goal = _ == 4)
 ```
 
@@ -182,13 +273,8 @@ val result = Traversal.bfs(start, visitor, goal = _ == 4)
 - If the start node satisfies the goal, traversal stops immediately with just the start node recorded.
 - If the goal is never met, the full graph is traversed (equivalent to `goal = _ => false`, the default).
 
-This works uniformly across `bfs`, `dfs`, `bestFirst`, and `bestFirstMax`. Combined with `bestFirst` and an appropriate `Ordering`, it gives you A\*-style goal-directed search.
-
-## Priority Queue
-
-The `PrioQueue[T]` type is backed by an immutable binary min-heap (`BinaryHeap`).
-It captures `Ordering[T]` at construction time, so the `Frontier[PrioQueue]` instance remains fully polymorphic.
-For weighted graph traversal, wrap your nodes as `(priority, node)` tuples with an appropriate `Ordering`.
+This works uniformly across `bfs`, `dfs`, `bestFirst`, `bestFirstMax`, and `bestFirstWeighted`.
+Combined with `bestFirst` and an appropriate `Ordering`, it gives you A\*-style goal-directed search.
 
 ## Immutability
 
@@ -199,10 +285,12 @@ The traversal loop threads all state explicitly — there are no `var`s anywhere
 ## Revision History
 
 | Version | Notes |
-|---------|---|
+|---------|-------|
 | 0.0.1   | First version |
 | 0.0.2   | Added `AutoCloseable` to `Appendable` and `Visitor` |
 | 0.0.3   | Added `FunctionMapJournal` |
 | 1.0.0   | Complete redesign: typeclass-driven architecture, `Frontier` abstraction, binary heap priority queue, Scala 3 throughout |
 | 1.1.0   | Added `DfsOrder` (pre/post-order DFS), `bestFirstMax`, American English type aliases |
-| 1.2.0   | Added `goal` predicate for early termination across all traversal methods; `traverseTree` now uses `Either`-stack supporting `DfsOrder` (no longer requires `Frontier[F]`) |
+| 1.2.0   | Added `goal` predicate for early termination across all traversal methods; `traverseTree` now uses `Either`-stack supporting `DfsOrder` |
+| 1.3.0   | Three-type priority queue hierarchy (`BinaryHeap`, `PrioQueue`, `IndexedPrioQueue`); `CostUpdate[W, F[_]]` typeclass; `TupleVisitedSet[(E,V)]`; `bestFirstWeighted` entry point for Dijkstra/Prim |
+| 1.4.0   | `Monoid[A]` typeclass with `given` instances for `Int`, `Long`, `Double`, `Float`; replaces `Numeric` in weighted traversal context bounds |

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 
 organization := "com.phasmidsoftware"
 
-version := "1.3.0"
+version := "1.4.0"
 
 val scalaVersionNumber  = "3.7.4"
 val scalaTestVersion    = "3.2.20"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 
 organization := "com.phasmidsoftware"
 
-version := "1.2.0"
+version := "1.3.0-SNAPSHOT"
 
 val scalaVersionNumber  = "3.7.4"
 val scalaTestVersion    = "3.2.19"

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@
 
 organization := "com.phasmidsoftware"
 
-version := "1.3.0-SNAPSHOT"
+version := "1.3.0"
 
 val scalaVersionNumber  = "3.7.4"
-val scalaTestVersion    = "3.2.19"
+val scalaTestVersion    = "3.2.20"
 val logbackVersion      = "1.5.32"
 val slf4jVersion        = "2.0.17"
 
@@ -51,9 +51,9 @@ lazy val root = (project in file("."))
 
     libraryDependencies ++= Seq(
       "org.slf4j"       %  "slf4j-api"         % slf4jVersion,
-      "ch.qos.logback"  %  "logback-classic"    % logbackVersion  % Runtime,
-      "org.scalatest"   %% "scalatest"          % scalaTestVersion % Test,
-      "com.novocode"    %  "junit-interface"     % "0.11"          % Test  // NOTE: known vulnerability
+      "ch.qos.logback"  %  "logback-classic"   % logbackVersion  % Runtime,
+      "org.scalatest"   %% "scalatest"         % scalaTestVersion % Test,
+      "com.novocode"    %  "junit-interface"    % "0.11"          % Test  // NOTE: known vulnerability
     )
   )
   .settings(scala3TestSettings)

--- a/docs/DEFERRED.md
+++ b/docs/DEFERRED.md
@@ -15,42 +15,77 @@ postponed for future attention.
    `given`/`using`.
 
 3. **Cats integration**
-   `Monoid` on `Journal` and `VisitedSet` as the natural entry point. Especially
-   relevant if parallel traversal is added. Intentionally kept separate for now
-   to avoid the dependency.
+   `Monoid[A]` was added in V1.4.0 as a home-grown typeclass (mirroring Cats)
+   to avoid the dependency. The remaining Cats integration question is whether to
+   also provide `Monoid[J]` on `Journal` and `Monoid[VisitedSet[V]]` — these are
+   the natural entry points for parallel traversal. Intentionally kept separate
+   for now.
 
 4. **Parallel traversal**
    Splitting the frontier and merging results. Would require `Monoid[J]` and
    `Monoid[VisitedSet[V]]` — a natural consequence of the Cats integration above.
 
+5. **`Monoid` vs `Ordering` relationship**
+   Considered making `Monoid[A] extends Ordering[A]` to allow a single context
+   bound `E: Monoid` for weighted traversals. Rejected: a monoid does not imply
+   an ordering (`String` concatenation is a valid monoid with no natural ordering),
+   and an ordering does not imply a monoid. The two context bounds `E: {Monoid, Ordering}`
+   are the honest design. Recorded here in case the question resurfaces.
+
 ## Code / Architecture
 
-5. **Visiting the root in `traverseTree`**
+6. **Visiting the root in `traverseTree`**
    The root `H` is currently never visited (no `Evaluable[H, R]` in scope).
    If visiting the root is needed, a variant taking an explicit `Evaluable[H, R]`
    parameter should be provided as a separate entry point.
-
-6. **`PrioQueue` and weighted graphs**
-   `BinaryHeap` allows duplicate nodes, which is correct for general use. For
-   weighted graph traversal with `(priority, node)` tuples, a decrease-key
-   operation or deduplication strategy may be needed.
 
 7. **Old `com.phasmidsoftware.visitor` package**
    `AppendableWriter` and `NonAppendable` have no equivalents in `core`. Decide
    whether they migrate into `core`, remain in a companion package, or are dropped.
 
-8. **Gryphon integration**
-   Wiring up Gryphon's graph types as `given Neighbours` and `given Evaluable`
-   instances. This will be the first real-world validation of the typeclass design.
-   Gryphon should depend on Visitor, not the other way around.
+8. **`IndexedPrioQueue.decreaseKey` performance**
+   Currently O(n log n): removes the old element by patching the array, rebuilds
+   the heap via a fold, then inserts the new element. Could be O(log n) by having
+   `BinaryHeap` expose position information from sift operations so the index can
+   be maintained incrementally. Acceptable for current graph sizes; revisit if
+   profiling ever justifies it. Target: Visitor V1.3.1 (patch, no API change).
+
+9. **`TraversalResult` vertex/edge duality**
+   `VertexTraversalResult` has an `edgeTraverse` stub that throws `GraphException`.
+   The design intends `TraversalResult` to support both vertex-keyed and edge-keyed
+   results, but only one is ever populated. The right solution is probably two
+   distinct result types rather than a single type with dead methods. Revisit when
+   Kruskal's MST (edge-keyed result) is implemented.
+
+## Gryphon — Future Work
+
+10. **Kosaraju's Strongly Connected Components**
+    Two DFS passes: first on the original graph (post-order), then on the reversed
+    graph. Requires `DirectedGraph.reverse` (not yet implemented). Lives alongside
+    `ConnectedComponents` in the `traverse` package.
+
+11. **Kruskal's MST**
+    Requires Union-Find. `UnionFindSpec` is currently entirely commented out;
+    `WeightedUnionFind` is in the attic. Does not use the `Traversal` engine —
+    it is edge-sorting plus Union-Find.
+
+12. **Verify Sedgewick & Wayne book coverage**
+    Systematically check that all graph algorithms from the course textbook are
+    implemented in Gryphon.
+
+13. **Merge `DijkstraTraversal` / `PrimTraversal` further**
+    Already merged into `WeightedTraversal`. The remaining duplication is in
+    `filterEdge` — Dijkstra admits only `AttributedDirectedEdge`, Prim admits all
+    edges. Consider whether a more general edge-filter abstraction is warranted,
+    or whether the current two-line override is clean enough as-is.
 
 ## Testing
 
-9. **More complex graph tests**
-   The more complex graph-based tests live in Gryphon, not Visitor. Importing them
-   directly would create an upward dependency (Visitor knowing about Gryphon), which
-   contradicts the architecture. Instead, those tests naturally exercise the Visitor
-   traversal engine as part of Gryphon's own test suite once Gryphon depends on Visitor.
-   The only candidates for migration would be pure graph-structural tests (cycle detection,
-   disconnected components, deep graphs stressing tail-recursion) that have no dependency
-   on Gryphon-specific types.
+14. **More complex graph tests**
+    The more complex graph-based tests live in Gryphon, not Visitor. Importing them
+    directly would create an upward dependency (Visitor knowing about Gryphon), which
+    contradicts the architecture. Instead, those tests naturally exercise the Visitor
+    traversal engine as part of Gryphon's own test suite once Gryphon depends on Visitor.
+    The only candidates for migration would be pure graph-structural tests (cycle detection,
+    disconnected components, deep graphs stressing tail-recursion) that have no dependency
+    on Gryphon-specific types.

--- a/src/main/scala/com/phasmidsoftware/visitor/core/Behaviours.scala
+++ b/src/main/scala/com/phasmidsoftware/visitor/core/Behaviours.scala
@@ -3,6 +3,54 @@ package com.phasmidsoftware.visitor.core
 import scala.collection.immutable.Queue
 
 // ============================================================
+// Monoid typeclass
+// ============================================================
+
+/**
+  * Typeclass: an associative binary operation with an identity element.
+  *
+  * Mirrors the Cats `Monoid` typeclass but without the Cats dependency.
+  * The standard additive monoids for numeric types are provided as `given`
+  * instances below.
+  *
+  * Primary use in Visitor/Gryphon: weighted graph traversals (Dijkstra, Prim)
+  * need `identity` as the seed cost and `combine` for cost accumulation —
+  * without requiring the full arithmetic of `Numeric`.
+  *
+  * @tparam A the element type
+  */
+trait Monoid[A]:
+  /** The identity element: `combine(identity, x) == x` for all x. */
+  def identity: A
+
+  /** An associative binary operation. */
+  def combine(x: A, y: A): A
+
+/** Additive monoid for [[Int]]. */
+given Monoid[Int] with
+  def identity: Int = 0
+
+  def combine(x: Int, y: Int): Int = x + y
+
+/** Additive monoid for [[Long]]. */
+given Monoid[Long] with
+  def identity: Long = 0L
+
+  def combine(x: Long, y: Long): Long = x + y
+
+/** Additive monoid for [[Double]]. */
+given Monoid[Double] with
+  def identity: Double = 0.0
+
+  def combine(x: Double, y: Double): Double = x + y
+
+/** Additive monoid for [[Float]]. */
+given Monoid[Float] with
+  def identity: Float = 0.0f
+
+  def combine(x: Float, y: Float): Float = x + y
+
+// ============================================================
 // Core typeclasses for the various behaviours
 // ============================================================
 
@@ -46,7 +94,6 @@ type GraphNeighbors[V] = GraphNeighbours[V]
   */
 trait VisitedSet[V]:
   def isVisited(v: V): Boolean
-
   def markVisited(v: V): VisitedSet[V]
 
 /** Default given: immutable Set-backed VisitedSet for plain node types. */
@@ -54,7 +101,6 @@ given [V]: VisitedSet[V] = SetVisitedSet(Set.empty)
 
 private case class SetVisitedSet[V](visited: Set[V]) extends VisitedSet[V]:
   def isVisited(v: V): Boolean = visited.contains(v)
-
   def markVisited(v: V): VisitedSet[V] = copy(visited + v)
 
 /**
@@ -75,7 +121,6 @@ given [E, V]: VisitedSet[(E, V)] = TupleVisitedSet(Set.empty)
 
 private case class TupleVisitedSet[E, V](visited: Set[V]) extends VisitedSet[(E, V)]:
   def isVisited(ev: (E, V)): Boolean = visited.contains(ev._2)
-
   def markVisited(ev: (E, V)): VisitedSet[(E, V)] = copy(visited + ev._2)
 
 // ============================================================
@@ -90,52 +135,14 @@ private case class TupleVisitedSet[E, V](visited: Set[V]) extends VisitedSet[(E,
   * @tparam F the higher-kinded frontier container type
   */
 trait Frontier[F[_]]:
-  /**
-    * Creates an empty frontier container of type F.
-    *
-    * @return an empty instance of the frontier container F[T]
-    */
   def empty[T]: F[T]
-
-  /**
-    * Adds a given element to the frontier container, returning an updated instance of the container.
-    *
-    * @param f the frontier container of type F[T] to which the element will be added
-    * @param t the element of type T to add to the frontier container
-    * @return a new instance of the frontier container F[T] with the element added
-    */
   def offer[T](f: F[T])(t: T): F[T]
-
-  /**
-    * Removes an element from the frontier container and returns a tuple containing the removed element
-    * and the updated container with the element removed.
-    *
-    * @param f the frontier container of type F[T] to extract the element from
-    * @return a tuple where the first element is the extracted element of type T and the second element
-    *         is the updated frontier container of type F[T]
-    */
   def take[T](f: F[T]): (T, F[T])
-
-  /**
-    * Determines if the given frontier container is empty.
-    *
-    * @param f the frontier container of type F[T] to be checked
-    * @return true if the frontier container is empty, false otherwise
-    */
   def isEmpty[T](f: F[T]): Boolean
 
   /** If true, offerAll reverses the list before offering (needed for LIFO stacks). */
   def reverseOnOffer: Boolean = false
 
-  /**
-    * Adds all elements from the given list to the specified frontier container in the order
-    * determined by the `reverseOnOffer` flag. If `reverseOnOffer` is true, the list of elements
-    * is reversed before being added. Each element is added using the `offer` method.
-    *
-    * @param f  the frontier container of type F[T] to which the elements will be added
-    * @param ts the list of elements of type T to add to the frontier container
-    * @return a new instance of the frontier container F[T] with all the elements added
-    */
   def offerAll[T](f: F[T])(ts: List[T]): F[T] =
     val ordered = if reverseOnOffer then ts.reverse else ts
     ordered.foldLeft(f)((acc, t) => offer(acc)(t))
@@ -197,7 +204,6 @@ given Frontier[IndexedPrioQueue] with
     throw new UnsupportedOperationException(
       "Supply an explicit `given IndexedPrioQueue[T] = IndexedPrioQueue.empty[T]` at the call site."
     )
-
   def offer[T](f: IndexedPrioQueue[T])(t: T): IndexedPrioQueue[T] = f.offer(t)
 
   def take[T](f: IndexedPrioQueue[T]): (T, IndexedPrioQueue[T]) = f.take
@@ -220,11 +226,7 @@ given Frontier[IndexedPrioQueue] with
   */
 trait Visitor[V, R, J <: Appendable[(V, Option[R])]]:
   def journal: J
-
-  /** Visit a single node, appending the result to the journal. */
   def visit(v: V)(using ev: Evaluable[V, R]): Visitor[V, R, J]
-
-  /** Return the completed journal. */
   def result: J = journal
 
 /** Canonical immutable implementation. */

--- a/src/main/scala/com/phasmidsoftware/visitor/core/Behaviours.scala
+++ b/src/main/scala/com/phasmidsoftware/visitor/core/Behaviours.scala
@@ -49,13 +49,34 @@ trait VisitedSet[V]:
 
   def markVisited(v: V): VisitedSet[V]
 
-/** Default given: immutable Set-backed VisitedSet. */
+/** Default given: immutable Set-backed VisitedSet for plain node types. */
 given [V]: VisitedSet[V] = SetVisitedSet(Set.empty)
 
 private case class SetVisitedSet[V](visited: Set[V]) extends VisitedSet[V]:
   def isVisited(v: V): Boolean = visited.contains(v)
 
   def markVisited(v: V): VisitedSet[V] = copy(visited + v)
+
+/**
+  * A `VisitedSet` for `(E, V)` frontier tuples used in weighted traversals
+  * (Dijkstra, Prim). Visited-ness is tracked on the vertex `V` alone —
+  * the cost component `E` is ignored — so that stale (higher-cost) copies
+  * of the same vertex in the frontier are correctly recognised as already visited.
+  *
+  * This given has higher priority than the plain `VisitedSet[V]` given because
+  * it is more specific: it matches only `(E, V)` pairs, not arbitrary `V`.
+  * It is resolved automatically whenever `Traversal` is invoked with a tuple
+  * frontier element type.
+  *
+  * @tparam E the cost / edge-weight type
+  * @tparam V the vertex type
+  */
+given [E, V]: VisitedSet[(E, V)] = TupleVisitedSet(Set.empty)
+
+private case class TupleVisitedSet[E, V](visited: Set[V]) extends VisitedSet[(E, V)]:
+  def isVisited(ev: (E, V)): Boolean = visited.contains(ev._2)
+
+  def markVisited(ev: (E, V)): VisitedSet[(E, V)] = copy(visited + ev._2)
 
 // ============================================================
 // Frontier typeclasses: Queueable and Stackable
@@ -117,7 +138,7 @@ trait Frontier[F[_]]:
     */
   def offerAll[T](f: F[T])(ts: List[T]): F[T] =
     val ordered = if reverseOnOffer then ts.reverse else ts
-    ordered.foldLeft(f)((acc: F[T], t: T) => offer(acc)(t))
+    ordered.foldLeft(f)((acc, t) => offer(acc)(t))
 
 /** DFS frontier: LIFO Stack (represented as a List). */
 type Stack[T] = List[T]
@@ -144,25 +165,44 @@ given Frontier[Queue] with
   def isEmpty[T](f: Queue[T]): Boolean = f.isEmpty
 
 /**
-  * Priority-queue frontier: best-first / Dijkstra-style traversal.
-  * Requires an Ordering[T] at the point of use.
+  * Priority-queue frontier: best-first traversal using [[PrioQueue]].
   *
-  * Backed by an immutable SortedSet for simplicity; swap for a proper
-  * binary heap if performance matters.
+  * Duplicates are permitted. Used by `bestFirst` and `bestFirstMax`.
+  * `Ordering[T]` is captured at `PrioQueue` construction time.
   *
-  * NOTE: T must have an Ordering and must be unique (no duplicate nodes
-  * in the frontier at the same priority). For weighted graphs you'd
-  * typically wrap nodes as (priority, node) tuples.
+  * Supply `given PrioQueue[T] = PrioQueue.empty[T]` (or `emptyMax`) at the call site.
   */
 given Frontier[PrioQueue] with
   def empty[T]: PrioQueue[T] =
-    throw new UnsupportedOperationException("Use PrioQueue.empty[T] directly")
-
+    throw new UnsupportedOperationException(
+      "Supply an explicit `given PrioQueue[T] = PrioQueue.empty[T]` at the call site."
+    )
   def offer[T](f: PrioQueue[T])(t: T): PrioQueue[T] = f.offer(t)
 
   def take[T](f: PrioQueue[T]): (T, PrioQueue[T]) = f.take
 
   def isEmpty[T](f: PrioQueue[T]): Boolean = f.isEmpty
+
+/**
+  * Indexed priority-queue frontier: best-first traversal using [[IndexedPrioQueue]].
+  *
+  * Duplicates are not permitted — `offer` is a no-op if the element is already
+  * present. Supports `decreaseKey` via [[CostUpdate]]. Used by `bestFirstWeighted`
+  * (Dijkstra, Prim).
+  *
+  * Supply `given IndexedPrioQueue[T] = IndexedPrioQueue.empty[T]` at the call site.
+  */
+given Frontier[IndexedPrioQueue] with
+  def empty[T]: IndexedPrioQueue[T] =
+    throw new UnsupportedOperationException(
+      "Supply an explicit `given IndexedPrioQueue[T] = IndexedPrioQueue.empty[T]` at the call site."
+    )
+
+  def offer[T](f: IndexedPrioQueue[T])(t: T): IndexedPrioQueue[T] = f.offer(t)
+
+  def take[T](f: IndexedPrioQueue[T]): (T, IndexedPrioQueue[T]) = f.take
+
+  def isEmpty[T](f: IndexedPrioQueue[T]): Boolean = f.isEmpty
 
 // ============================================================
 // Visitor

--- a/src/main/scala/com/phasmidsoftware/visitor/core/CostUpdate.scala
+++ b/src/main/scala/com/phasmidsoftware/visitor/core/CostUpdate.scala
@@ -1,0 +1,44 @@
+package com.phasmidsoftware.visitor.core
+
+// ============================================================
+// CostUpdate typeclass
+// ============================================================
+
+/**
+  * Typeclass: after a node is settled (dequeued and marked visited) and its
+  * neighbours have been offered to the frontier, optionally update the
+  * priorities of frontier entries that have improved.
+  *
+  * This typeclass exists to support `decreaseKey` in Dijkstra- and Prim-style
+  * traversals. It keeps all domain knowledge (cost maps, edge weights, the
+  * notion of "improvement") out of [[Traversal]] itself.
+  *
+  * For DFS and BFS the default no-op given is resolved automatically.
+  * For Dijkstra and Prim, the `GraphTraversal` implementation supplies a
+  * concrete `given CostUpdate[W, IndexedPrioQueue]` (where `W = (E, V)`) that
+  * closes over a secondary vertex→cost map and calls [[IndexedPrioQueue.decreaseKey]]
+  * for any neighbour whose cost has improved since it was first offered.
+  *
+  * @tparam W the frontier element type (e.g. `(E, V)` for weighted traversals,
+  *           or plain `V` for DFS / BFS)
+  *
+  * @tparam F the frontier container type (e.g. [[PrioQueue]], [[Stack]], Queue)
+  */
+trait CostUpdate[W, F[_]]:
+  /**
+    * Given the current frontier and the node `w` that was just settled,
+    * return an updated frontier with any improved priorities applied.
+    *
+    * @param frontier the frontier after `w`'s neighbours have been offered
+    * @param w        the element that was just settled
+    * @return the frontier with any `decreaseKey` updates applied
+    */
+  def update(frontier: F[W], w: W): F[W]
+
+/**
+  * Default no-op implementation.
+  * Resolved automatically for DFS (`Stack`) and BFS (`Queue`) traversals,
+  * and for any weighted traversal that does not need re-keying.
+  */
+given [W, F[_]]: CostUpdate[W, F] with
+  def update(frontier: F[W], w: W): F[W] = frontier

--- a/src/main/scala/com/phasmidsoftware/visitor/core/PrioQueue.scala
+++ b/src/main/scala/com/phasmidsoftware/visitor/core/PrioQueue.scala
@@ -2,38 +2,60 @@ package com.phasmidsoftware.visitor.core
 
 import scala.annotation.tailrec
 
+// ============================================================
+// BinaryHeap — pure data structure
+// ============================================================
+
 /**
-  * An immutable binary min-heap, used as the backing structure for [[PrioQueue]].
+  * An immutable binary min-heap.
   *
-  * Implemented as a standard array-based heap over a Vector for structural sharing.
+  * This is a pure data structure: it knows only about the heap array and the
+  * two structural operations that maintain the heap invariant (sift-up and
+  * sift-down). It has no knowledge of indexing, deduplication, or priority
+  * queue policy — those concerns belong to [[PrioQueue]] and [[IndexedPrioQueue]].
+  *
+  * The heap is 0-indexed: root at index 0, children of node i at 2i+1 and 2i+2.
   * All operations are O(log n) except [[isEmpty]] which is O(1).
   *
-  * @param data the heap array (1-indexed: root at index 1, children of i at 2i and 2i+1)
+  * @param data the heap array
   * @param ord  the ordering used to maintain the heap invariant
   * @tparam T the element type
   */
-private case class BinaryHeap[T](data: Vector[T])(using ord: Ordering[T]):
+private[core] case class BinaryHeap[T](data: Vector[T])(using val ord: Ordering[T]):
 
   def isEmpty: Boolean = data.isEmpty
 
-  /** Insert an element, restoring the heap invariant by sifting up. O(log n). */
+  def size: Int = data.size
+
+  def head: T =
+    require(data.nonEmpty, "head on empty heap")
+    data(0)
+
+  /**
+    * Insert a new element, restoring the heap invariant by sifting up. O(log n).
+    * Duplicate elements are permitted.
+    */
   def insert(t: T): BinaryHeap[T] =
     val appended = data :+ t
     copy(data = siftUp(appended, appended.size - 1))
 
-  /** Remove and return the minimum element, restoring the heap invariant by sifting down. O(log n). */
+  /**
+    * Remove and return the minimum element, restoring the heap invariant by
+    * sifting down. O(log n). Requires the heap to be non-empty.
+    */
   def removeMin: (T, BinaryHeap[T]) =
     require(data.nonEmpty, "removeMin on empty heap")
-    val min = data.head
-    val rest = if data.size == 1 then Vector.empty[T]
-    else siftDown(data.last +: data.tail.init, 0)
-    (min, copy(data = rest))
+    val min = data(0)
+    if data.size == 1 then
+      (min, copy(data = Vector.empty))
+    else
+      val promoted = data.updated(0, data.last).init
+      (min, copy(data = siftDown(promoted, 0)))
 
-  def head: T =
-    require(data.nonEmpty, "head on empty heap")
-    data.head
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
 
-  // Sift the element at index i upward until the heap invariant is restored.
   @tailrec
   private def siftUp(v: Vector[T], i: Int): Vector[T] =
     if i == 0 then v
@@ -42,47 +64,43 @@ private case class BinaryHeap[T](data: Vector[T])(using ord: Ordering[T]):
       if ord.lteq(v(parent), v(i)) then v
       else siftUp(v.updated(i, v(parent)).updated(parent, v(i)), parent)
 
-  // Sift the element at index i downward until the heap invariant is restored.
-  @annotation.tailrec
+  @tailrec
   private def siftDown(v: Vector[T], i: Int): Vector[T] =
     val left = 2 * i + 1
     val right = 2 * i + 2
+    val n = v.size
     val smallest =
-      if left < v.size && ord.lt(v(left), v(i)) then left
-      else i
+      if left < n && ord.lt(v(left), v(i)) then left else i
     val smallest2 =
-      if right < v.size && ord.lt(v(right), v(smallest)) then right
-      else smallest
+      if right < n && ord.lt(v(right), v(smallest)) then right else smallest
     if smallest2 == i then v
     else siftDown(v.updated(i, v(smallest2)).updated(smallest2, v(i)), smallest2)
 
-/**
-  * Factory methods for creating instances of the BinaryHeap.
-  *
-  * A BinaryHeap is a priority queue data structure that maintains the heap
-  * property, enabling efficient insertion and removal of elements based 
-  * on their priority.
-  */
-object BinaryHeap:
+private[core] object BinaryHeap:
   def empty[T: Ordering]: BinaryHeap[T] = BinaryHeap(Vector.empty)
 
 // ============================================================
-// PrioQueue — public wrapper around BinaryHeap
+// PrioQueue — priority queue ADT, delegates to BinaryHeap
 // ============================================================
 
 /**
-  * An immutable priority queue backed by a [[BinaryHeap]].
+  * An immutable priority queue ADT backed by [[BinaryHeap]].
   *
-  * Captures [[Ordering]] at construction time so that [[Frontier]][PrioQueue]
-  * can remain fully polymorphic without needing an `Ordering` context at
-  * every `offer` / `take` call.
+  * Duplicates are permitted. The minimum element is dequeued first
+  * (or maximum via [[PrioQueue.emptyMax]]).
   *
-  * Minimum element is dequeued first.
+  * [[Ordering]][T] is captured at construction time so that
+  * [[Frontier]][PrioQueue] remains fully polymorphic — no `Ordering`
+  * context is needed at `offer` / `take` call sites.
+  *
+  * For a priority queue that also supports O(log n) `decreaseKey`,
+  * see [[IndexedPrioQueue]].
   *
   * @param heap the underlying binary heap
   * @tparam T the element type
   */
 case class PrioQueue[T] private(private val heap: BinaryHeap[T]):
+
   def offer(t: T): PrioQueue[T] = copy(heap = heap.insert(t))
 
   def take: (T, PrioQueue[T]) =
@@ -91,14 +109,107 @@ case class PrioQueue[T] private(private val heap: BinaryHeap[T]):
 
   def isEmpty: Boolean = heap.isEmpty
 
+  def size: Int = heap.size
+
   def head: T = heap.head
 
-/**
-  * Provides factory methods for creating instances of `PrioQueue` with different priority orderings.
-  */
 object PrioQueue:
   /** Min-priority queue — smallest element dequeued first. */
-  def empty[T: Ordering]: PrioQueue[T] = PrioQueue(BinaryHeap.empty[T])
+  def empty[T: Ordering]: PrioQueue[T] =
+    PrioQueue(BinaryHeap.empty[T])
 
   /** Max-priority queue — largest element dequeued first. */
-  def emptyMax[T: Ordering]: PrioQueue[T] = PrioQueue(BinaryHeap.empty[T](using Ordering[T].reverse))
+  def emptyMax[T: Ordering]: PrioQueue[T] =
+    PrioQueue(BinaryHeap.empty[T](using Ordering[T].reverse))
+
+// ============================================================
+// IndexedPrioQueue — PrioQueue ADT extended with decreaseKey
+// ============================================================
+
+/**
+  * An immutable indexed priority queue ADT backed by [[BinaryHeap]].
+  *
+  * Extends the [[PrioQueue]] contract with O(log n) `decreaseKey` and O(1)
+  * `contains`, enabled by a `Map[T, Int]` index that tracks each element's
+  * current position in the heap array.
+  *
+  * Unlike [[PrioQueue]], duplicates are not permitted: `offer` is a no-op if
+  * the element is already present. Use `decreaseKey` to improve an existing
+  * entry's priority. This one-entry-per-key invariant is what makes the index
+  * meaningful and `decreaseKey` correct.
+  *
+  * The index is rebuilt from `heap.data` (O(n)) after each structural operation
+  * (`offer` and `take`). This is acceptable because:
+  *   - the O(n) rebuild cost is dominated by the O(E log V) traversal cost
+  *   - the implementation remains simple, correct, and easy to reason about
+  *
+  * Minimum element is dequeued first (or maximum via [[IndexedPrioQueue.emptyMax]]).
+  *
+  * @param heap  the underlying binary heap
+  * @param index a map from element to its current 0-based position in heap.data
+  * @tparam T the element type
+  */
+case class IndexedPrioQueue[T] private(
+                                        private[core] val heap: BinaryHeap[T],
+                                        private val index: Map[T, Int]
+                                      ):
+
+  def isEmpty: Boolean = heap.isEmpty
+
+  def size: Int = heap.size
+
+  def head: T = heap.head
+
+  /**
+    * Add an element. No-op if the element is already present — use `decreaseKey`
+    * to improve its priority. O(n) due to index rebuild.
+    */
+  def offer(t: T): IndexedPrioQueue[T] =
+    if index.contains(t) then this
+    else IndexedPrioQueue.fromHeap(heap.insert(t))
+
+  /**
+    * Remove and return the minimum element. O(n) due to index rebuild.
+    */
+  def take: (T, IndexedPrioQueue[T]) =
+    val (min, h) = heap.removeMin
+    (min, IndexedPrioQueue.fromHeap(h))
+
+  /**
+    * Replace `oldT` with `newT` if `newT` has strictly lower priority.
+    * If `oldT` is not present, this is a no-op.
+    *
+    * Implemented by removing `oldT` from the heap array, inserting `newT`,
+    * and rebuilding the heap from scratch. O(n log n) in the worst case, but
+    * correct and simple. The index is rebuilt after the operation. O(n).
+    */
+  def decreaseKey(oldT: T, newT: T): IndexedPrioQueue[T] =
+    index.get(oldT) match
+      case None => this
+      case Some(i) =>
+        if heap.ord.lteq(heap.data(i), newT) then this
+        else
+          val withoutOld = heap.data.patch(i, Nil, 1)
+          val rebuilt = withoutOld.foldLeft(BinaryHeap.empty[T](using heap.ord))(
+            (h, t) => h.insert(t)
+          ).insert(newT)
+          IndexedPrioQueue.fromHeap(rebuilt)
+
+  /**
+    * Returns true if `t` is currently in the queue. O(1).
+    */
+  def contains(t: T): Boolean = index.contains(t)
+
+object IndexedPrioQueue:
+
+  /** Rebuild the index from the heap's data array. O(n). */
+  private def fromHeap[T](h: BinaryHeap[T]): IndexedPrioQueue[T] =
+    IndexedPrioQueue(h, h.data.zipWithIndex.toMap)
+
+  /** Min-priority indexed queue — smallest element dequeued first. */
+  def empty[T: Ordering]: IndexedPrioQueue[T] =
+    IndexedPrioQueue(BinaryHeap.empty[T], Map.empty)
+
+  /** Max-priority indexed queue — largest element dequeued first. */
+  def emptyMax[T: Ordering]: IndexedPrioQueue[T] =
+    IndexedPrioQueue(BinaryHeap.empty[T](using Ordering[T].reverse), Map.empty)

--- a/src/main/scala/com/phasmidsoftware/visitor/core/Traversal.scala
+++ b/src/main/scala/com/phasmidsoftware/visitor/core/Traversal.scala
@@ -17,7 +17,7 @@ enum DfsOrder:
 
 /**
   * The traversal engine. Knows only about Frontier, Neighbours, Evaluable,
-  * VisitedSet, and Visitor. Zero domain knowledge.
+  * VisitedSet, Visitor, and CostUpdate. Zero domain knowledge.
   *
   * The choice of frontier F determines the traversal order:
   * F = Queue     → BFS
@@ -29,6 +29,10 @@ object Traversal:
   /**
     * Traverses a (homogeneous) graph structure starting from a given node, visiting nodes
     * iteratively and accumulating results into a visitor.
+    *
+    * After each node's neighbours are offered to the frontier, `cu.update` is called
+    * to apply any priority improvements (e.g. `decreaseKey` in Dijkstra/Prim).
+    * For DFS and BFS the default no-op [[CostUpdate]] is resolved automatically.
     *
     * The start node is always visited and recorded first, before any goal check or
     * frontier expansion. If `goal(start)` is true, traversal stops immediately after
@@ -42,10 +46,12 @@ object Traversal:
     * @param visitor An instance of `Visitor` that collects results during traversal.
     * @param goal    A predicate that, when true for a visited node, halts the traversal
     *                after recording that node. Defaults to never stopping early.
-    * @param nbrs    A typeclass instance providing the neighbours for each node in the graph.
-    * @param ev      A typeclass instance defining how to extract results from each node.
-    * @param vs      A typeclass instance representing the set of visited nodes to prevent revisiting.
-    * @param fr      A typeclass instance representing the frontier structure used for traversal.
+    *
+    * @param nbrs    Typeclass providing the neighbours for each node.
+    * @param ev      Typeclass defining how to extract results from each node.
+    * @param vs      Typeclass representing the set of visited nodes to prevent revisiting.
+    * @param fr      Typeclass representing the frontier structure used for traversal.
+    * @param cu      Typeclass for post-settle priority updates (no-op for DFS/BFS).
     * @param initial The initial empty frontier structure for the traversal.
     * @return A `Visitor` instance containing the accumulated results after traversal completes.
     */
@@ -58,6 +64,7 @@ object Traversal:
                                                              ev: Evaluable[V, R],
                                                              vs: VisitedSet[V],
                                                              fr: Frontier[F],
+                                                             cu: CostUpdate[V, F],
                                                              initial: F[V]
                                                            ): Visitor[V, R, J] =
 
@@ -76,17 +83,17 @@ object Traversal:
           val newVisitor = vis.visit(node)
           if goal(node) then newVisitor
           else
-            val newFrontier = fr.offerAll(rest)(
+            val offered = fr.offerAll(rest)(
               nbrs.neighbours(node).filterNot(newVisited.isVisited).toList
             )
+            val newFrontier = cu.update(offered, node)
             loop(newFrontier, newVisitor, newVisited)
 
-    // Visit start first, then check goal before entering the loop.
-    // This ensures goal(start) stops traversal immediately with just the start node recorded.
     val startVisitor = visitor.visit(start)
     if goal(start) then startVisitor
     else
-      val seedFrontier = fr.offerAll(initial)(nbrs.neighbours(start).toList)
+      val seedOffered = fr.offerAll(initial)(nbrs.neighbours(start).toList)
+      val seedFrontier = cu.update(seedOffered, start)
       loop(seedFrontier, startVisitor, vs.markVisited(start))
 
   /**
@@ -143,13 +150,11 @@ object Traversal:
       stack match
         case Nil => vis
 
-        // Record frame: visit the node, then check goal
         case Right(node) :: rest =>
           val newVisitor = vis.visit(node)
           if goal(node) then newVisitor
           else loop(rest, newVisitor, visited)
 
-        // Expand frame: if already visited skip; otherwise mark and push frames
         case Left(node) :: rest =>
           if visited.isVisited(node) then loop(rest, vis, visited)
           else
@@ -161,7 +166,6 @@ object Traversal:
               case DfsOrder.Post => childFrames ::: (Right(node) :: rest)
             loop(newStack, vis, newVisited)
 
-    // Seed from root using rootNbrs (H → V), then hand off to the Either-stack loop
     val seedFrames: List[Frame] = rootNbrs.neighbours(start).map(Left(_)).toList
     loop(seedFrames, visitor, vs)
 
@@ -189,7 +193,6 @@ object Traversal:
                                                   vs: VisitedSet[V]
                                                 ): Visitor[V, R, J] =
     given Queue[V] = Queue.empty
-
     traverse[V, R, J, Queue](start, visitor, goal)
 
   /**
@@ -231,13 +234,11 @@ object Traversal:
       stack match
         case Nil => vis
 
-        // Record frame: visit the node, then check goal
         case Right(node) :: rest =>
           val newVisitor = vis.visit(node)
           if goal(node) then newVisitor
           else loop(rest, newVisitor, visited)
 
-        // Expand frame: if already visited skip; otherwise mark and push frames
         case Left(node) :: rest =>
           if visited.isVisited(node) then loop(rest, vis, visited)
           else
@@ -255,10 +256,6 @@ object Traversal:
     * Best-first / min-priority-queue traversal. Smallest element dequeued first.
     * Requires Ordering[V] in scope.
     *
-    * The start node is always recorded first. If `goal(start)` is true, traversal
-    * stops immediately. For all other nodes, traversal stops after recording the
-    * first node satisfying `goal`.
-    *
     * @param goal optional early-termination predicate. Defaults to never stopping early.
     */
   def bestFirst[V: Ordering, R, J <: Appendable[(V, Option[R])]](
@@ -271,16 +268,11 @@ object Traversal:
                                                                   vs: VisitedSet[V]
                                                                 ): Visitor[V, R, J] =
     given PrioQueue[V] = PrioQueue.empty[V]
-
     traverse[V, R, J, PrioQueue](start, visitor, goal)
 
   /**
     * Best-first / max-priority-queue traversal. Largest element dequeued first.
     * Requires Ordering[V] in scope.
-    *
-    * The start node is always recorded first. If `goal(start)` is true, traversal
-    * stops immediately. For all other nodes, traversal stops after recording the
-    * first node satisfying `goal`.
     *
     * @param goal optional early-termination predicate. Defaults to never stopping early.
     */
@@ -294,5 +286,34 @@ object Traversal:
                                                                      vs: VisitedSet[V]
                                                                    ): Visitor[V, R, J] =
     given PrioQueue[V] = PrioQueue.emptyMax[V]
-
     traverse[V, R, J, PrioQueue](start, visitor, goal)
+
+  /**
+    * Best-first traversal with an explicit `CostUpdate` — for Dijkstra and Prim.
+    *
+    * The frontier element type `W` is typically `(E, V)` where `E` is the cost
+    * type and `V` is the vertex type. The caller supplies:
+    *   - `start`: the seed element, e.g. `(zero, startVertex)`
+    *   - a `given IndexedPrioQueue[W] = IndexedPrioQueue.empty[W]` (always empty;
+    *     `traverse` seeds the frontier from `start`'s neighbours)
+    *   - a `given CostUpdate[W, IndexedPrioQueue]` that calls `decreaseKey` after
+    *     each settle
+    *   - `Neighbours[W, W]` expanding `(cost, vertex)` to `(newCost, neighbour)` pairs
+    *
+    * This overload is the intended entry point for Gryphon's `DijkstraTraversal`
+    * and `PrimTraversal`.
+    *
+    * @param goal optional early-termination predicate.
+    */
+  def bestFirstWeighted[W: Ordering, R, J <: Appendable[(W, Option[R])]](
+                                                                          start: W,
+                                                                          visitor: Visitor[W, R, J],
+                                                                          goal: W => Boolean = (_: W) => false
+                                                                        )(using
+                                                                          nbrs: GraphNeighbours[W],
+                                                                          ev: Evaluable[W, R],
+                                                                          vs: VisitedSet[W],
+                                                                          cu: CostUpdate[W, IndexedPrioQueue],
+                                                                          initial: IndexedPrioQueue[W]
+                                                                        ): Visitor[W, R, J] =
+    traverse[W, R, J, IndexedPrioQueue](start, visitor, goal)

--- a/src/main/scala/com/phasmidsoftware/visitor/core/Traversal.scala
+++ b/src/main/scala/com/phasmidsoftware/visitor/core/Traversal.scala
@@ -83,9 +83,8 @@ object Traversal:
           val newVisitor = vis.visit(node)
           if goal(node) then newVisitor
           else
-            val offered = fr.offerAll(rest)(
-              nbrs.neighbours(node).filterNot(newVisited.isVisited).toList
-            )
+            val neighbourList = nbrs.neighbours(node).filterNot(newVisited.isVisited).toList
+            val offered = fr.offerAll(rest)(neighbourList)
             val newFrontier = cu.update(offered, node)
             loop(newFrontier, newVisitor, newVisited)
 

--- a/src/test/scala/com/phasmidsoftware/visitor/core/BinaryHeapSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/visitor/core/BinaryHeapSpec.scala
@@ -1,0 +1,123 @@
+package com.phasmidsoftware.visitor.core
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * Tests for [[BinaryHeap]] — the pure data structure layer.
+  *
+  * BinaryHeap is private[core] so these tests are in the same package.
+  * Tests focus on structural correctness: heap invariant, insert, removeMin,
+  * and duplicate handling. Policy concerns (deduplication, decreaseKey) are
+  * tested in [[IndexedPrioQueueSpec]].
+  */
+class BinaryHeapSpec extends AnyFlatSpec with Matchers:
+
+  // -----------------------------------------------------------------------
+  // Construction
+  // -----------------------------------------------------------------------
+
+  "BinaryHeap" should "be empty on construction" in:
+    val h = BinaryHeap.empty[Int]
+    h.isEmpty shouldBe true
+    h.size shouldBe 0
+
+  it should "not be empty after a single insert" in:
+    val h = BinaryHeap.empty[Int].insert(1)
+    h.isEmpty shouldBe false
+    h.size shouldBe 1
+
+  it should "expose the minimum element via head without removing it" in:
+    val h = BinaryHeap.empty[Int].insert(3).insert(1).insert(2)
+    h.head shouldBe 1
+    h.size shouldBe 3  // head is non-destructive
+
+  it should "throw on head of empty heap" in:
+    an[IllegalArgumentException] should be thrownBy BinaryHeap.empty[Int].head
+
+  it should "throw on removeMin of empty heap" in:
+    an[IllegalArgumentException] should be thrownBy BinaryHeap.empty[Int].removeMin
+
+  // -----------------------------------------------------------------------
+  // Insert and removeMin — ordering
+  // -----------------------------------------------------------------------
+
+  it should "removeMin a single element correctly" in:
+    val h = BinaryHeap.empty[Int].insert(42)
+    val (x, h2) = h.removeMin
+    x shouldBe 42
+    h2.isEmpty shouldBe true
+
+  it should "always dequeue in ascending order regardless of insertion order" in:
+    val h = BinaryHeap.empty[Int].insert(5).insert(3).insert(1).insert(4).insert(2)
+    val (a, h1) = h.removeMin
+    val (b, h2) = h1.removeMin
+    val (c, h3) = h2.removeMin
+    val (d, h4) = h3.removeMin
+    val (e, _)  = h4.removeMin
+    List(a, b, c, d, e) shouldBe List(1, 2, 3, 4, 5)
+
+  it should "dequeue in ascending order when inserted in ascending order" in:
+    val h = BinaryHeap.empty[Int].insert(1).insert(2).insert(3)
+    val (a, h1) = h.removeMin
+    val (b, h2) = h1.removeMin
+    val (c, _)  = h2.removeMin
+    List(a, b, c) shouldBe List(1, 2, 3)
+
+  it should "dequeue in ascending order when inserted in descending order" in:
+    val h = BinaryHeap.empty[Int].insert(3).insert(2).insert(1)
+    val (a, h1) = h.removeMin
+    val (b, h2) = h1.removeMin
+    val (c, _)  = h2.removeMin
+    List(a, b, c) shouldBe List(1, 2, 3)
+
+  it should "maintain heap invariant after each removeMin on a larger heap" in:
+    val elems = List(7, 2, 9, 1, 5, 3, 8, 4, 6)
+    val h     = elems.foldLeft(BinaryHeap.empty[Int])(_.insert(_))
+    val result = Iterator.unfold(h) { heap =>
+      if heap.isEmpty then None
+      else Some(heap.removeMin)
+    }.toList
+    result shouldBe elems.sorted
+
+  // -----------------------------------------------------------------------
+  // Duplicates
+  // -----------------------------------------------------------------------
+
+  it should "permit duplicate elements" in:
+    val h = BinaryHeap.empty[Int].insert(2).insert(1).insert(2).insert(1)
+    h.size shouldBe 4
+
+  it should "dequeue duplicates in non-decreasing order" in:
+    val h = BinaryHeap.empty[Int].insert(2).insert(1).insert(2).insert(1)
+    val (a, h1) = h.removeMin
+    val (b, h2) = h1.removeMin
+    val (c, h3) = h2.removeMin
+    val (d, _)  = h3.removeMin
+    List(a, b, c, d) shouldBe List(1, 1, 2, 2)
+
+  it should "handle a heap of all identical elements" in:
+    val h = BinaryHeap.empty[Int].insert(5).insert(5).insert(5)
+    val (a, h1) = h.removeMin
+    val (b, h2) = h1.removeMin
+    val (c, _)  = h2.removeMin
+    List(a, b, c) shouldBe List(5, 5, 5)
+
+  // -----------------------------------------------------------------------
+  // Ordering variants
+  // -----------------------------------------------------------------------
+
+  it should "work as a max-heap when given a reversed Ordering" in:
+    given Ordering[Int] = Ordering.Int.reverse
+    val h = BinaryHeap.empty[Int].insert(1).insert(3).insert(2)
+    val (a, h1) = h.removeMin  // removeMin on reversed ordering = removeMax
+    val (b, h2) = h1.removeMin
+    val (c, _)  = h2.removeMin
+    List(a, b, c) shouldBe List(3, 2, 1)
+
+  it should "work correctly with a String ordering" in:
+    val h = BinaryHeap.empty[String].insert("banana").insert("apple").insert("cherry")
+    val (a, h1) = h.removeMin
+    val (b, h2) = h1.removeMin
+    val (c, _)  = h2.removeMin
+    List(a, b, c) shouldBe List("apple", "banana", "cherry")

--- a/src/test/scala/com/phasmidsoftware/visitor/core/IndexedPrioQueueSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/visitor/core/IndexedPrioQueueSpec.scala
@@ -1,0 +1,189 @@
+package com.phasmidsoftware.visitor.core
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * Tests for [[IndexedPrioQueue]] — the indexed priority queue ADT layer.
+  *
+  * IndexedPrioQueue extends the [[PrioQueue]] contract with:
+  *   - deduplication on `offer` (one entry per key)
+  *   - `decreaseKey` — O(n log n) re-prioritisation of an existing entry
+  *   - `contains` — O(1) membership test
+  *
+  * These are the operations required by [[CostUpdate]] in Dijkstra/Prim traversals.
+  */
+class IndexedPrioQueueSpec extends AnyFlatSpec with Matchers:
+
+  // -----------------------------------------------------------------------
+  // Construction
+  // -----------------------------------------------------------------------
+
+  "IndexedPrioQueue.empty" should "be empty" in:
+    IndexedPrioQueue.empty[Int].isEmpty shouldBe true
+    IndexedPrioQueue.empty[Int].size shouldBe 0
+
+  it should "not be empty after offer" in:
+    val pq = IndexedPrioQueue.empty[Int].offer(1)
+    pq.isEmpty shouldBe false
+    pq.size shouldBe 1
+
+  // -----------------------------------------------------------------------
+  // Offer / take ordering
+  // -----------------------------------------------------------------------
+
+  "IndexedPrioQueue (min)" should "dequeue elements in ascending order" in:
+    val pq = IndexedPrioQueue.empty[Int].offer(3).offer(1).offer(2)
+    val (a, pq1) = pq.take
+    val (b, pq2) = pq1.take
+    val (c, _)   = pq2.take
+    List(a, b, c) shouldBe List(1, 2, 3)
+
+  it should "expose the minimum via head without removing it" in:
+    val pq = IndexedPrioQueue.empty[Int].offer(3).offer(1).offer(2)
+    pq.head shouldBe 1
+    pq.size shouldBe 3
+
+  it should "dequeue a single element correctly" in:
+    val pq = IndexedPrioQueue.empty[Int].offer(7)
+    val (x, pq2) = pq.take
+    x shouldBe 7
+    pq2.isEmpty shouldBe true
+
+  it should "dequeue in ascending order regardless of insertion order" in:
+    val pq = IndexedPrioQueue.empty[Int].offer(5).offer(2).offer(8).offer(1).offer(9).offer(3)
+    val result = Iterator.unfold(pq) { q =>
+      if q.isEmpty then None else Some(q.take)
+    }.toList
+    result shouldBe List(1, 2, 3, 5, 8, 9)
+
+  // -----------------------------------------------------------------------
+  // Deduplication — one entry per key
+  // -----------------------------------------------------------------------
+
+  it should "treat duplicate offer as a no-op" in:
+    val pq  = IndexedPrioQueue.empty[Int].offer(1).offer(2)
+    val pq2 = pq.offer(1)  // duplicate — should be ignored
+    pq2.size shouldBe 2
+
+  it should "contain the element after offer, not after take" in:
+    val pq = IndexedPrioQueue.empty[Int].offer(1).offer(2)
+    pq.contains(1) shouldBe true
+    pq.contains(2) shouldBe true
+    pq.contains(3) shouldBe false
+    val (_, pq2) = pq.take  // removes 1
+    pq2.contains(1) shouldBe false
+    pq2.contains(2) shouldBe true
+
+  it should "not grow when the same element is offered repeatedly" in:
+    val pq = (1 to 5).foldLeft(IndexedPrioQueue.empty[Int].offer(42)) { (q, _) => q.offer(42) }
+    pq.size shouldBe 1
+
+  // -----------------------------------------------------------------------
+  // decreaseKey
+  // -----------------------------------------------------------------------
+
+  it should "decreaseKey repositions an existing entry so it dequeues earlier" in:
+    // Start: [3, 5, 7] — decrease 7 to 1
+    val pq  = IndexedPrioQueue.empty[Int].offer(3).offer(5).offer(7)
+    val pq2 = pq.decreaseKey(7, 1)
+    val (a, pq3) = pq2.take
+    val (b, pq4) = pq3.take
+    val (c, _)   = pq4.take
+    List(a, b, c) shouldBe List(1, 3, 5)
+
+  it should "decreaseKey on the current minimum has no visible effect on order" in:
+    val pq  = IndexedPrioQueue.empty[Int].offer(1).offer(3).offer(5)
+    val pq2 = pq.decreaseKey(1, 0)
+    val (a, pq3) = pq2.take
+    val (b, pq4) = pq3.take
+    val (c, _)   = pq4.take
+    List(a, b, c) shouldBe List(0, 3, 5)
+
+  it should "decreaseKey on an absent element is a no-op" in:
+    val pq  = IndexedPrioQueue.empty[Int].offer(1).offer(2)
+    val pq2 = pq.decreaseKey(99, 0)  // 99 not present
+    pq2.size shouldBe 2
+    pq2.contains(99) shouldBe false
+    pq2.contains(0)  shouldBe false
+
+  it should "decreaseKey with a non-improving priority is a no-op" in:
+    val pq  = IndexedPrioQueue.empty[Int].offer(1).offer(3)
+    val pq2 = pq.decreaseKey(1, 5)  // 5 > 1 — not an improvement
+    pq2.size shouldBe 2
+    val (a, _) = pq2.take
+    a shouldBe 1  // original value still at head
+
+  it should "decreaseKey preserves all other elements" in:
+    val pq  = IndexedPrioQueue.empty[Int].offer(10).offer(20).offer(30).offer(40)
+    val pq2 = pq.decreaseKey(40, 5)
+    val result = Iterator.unfold(pq2) { q =>
+      if q.isEmpty then None else Some(q.take)
+    }.toList
+    result shouldBe List(5, 10, 20, 30)
+
+  it should "support multiple decreaseKey calls on different elements" in:
+    val pq  = IndexedPrioQueue.empty[Int].offer(10).offer(20).offer(30)
+    val pq2 = pq.decreaseKey(30, 5).decreaseKey(20, 1)
+    val result = Iterator.unfold(pq2) { q =>
+      if q.isEmpty then None else Some(q.take)
+    }.toList
+    result shouldBe List(1, 5, 10)
+
+  // -----------------------------------------------------------------------
+  // Max-priority variant
+  // -----------------------------------------------------------------------
+
+  "IndexedPrioQueue.emptyMax" should "dequeue elements in descending order" in:
+    val pq = IndexedPrioQueue.emptyMax[Int].offer(1).offer(3).offer(2)
+    val (a, pq1) = pq.take
+    val (b, pq2) = pq1.take
+    val (c, _)   = pq2.take
+    List(a, b, c) shouldBe List(3, 2, 1)
+
+  it should "treat duplicate offer as a no-op" in:
+    val pq  = IndexedPrioQueue.emptyMax[Int].offer(1).offer(2)
+    val pq2 = pq.offer(2)
+    pq2.size shouldBe 2
+
+  // -----------------------------------------------------------------------
+  // Frontier[IndexedPrioQueue] integration
+  // -----------------------------------------------------------------------
+
+  "Frontier[IndexedPrioQueue]" should "offer and take in ascending priority order" in:
+    val fr  = summon[Frontier[IndexedPrioQueue]]
+    val pq  = IndexedPrioQueue.empty[Int]
+    val pq1 = fr.offer(fr.offer(fr.offer(pq)(3))(1))(2)
+    val (a, pq2) = fr.take(pq1)
+    val (b, pq3) = fr.take(pq2)
+    val (c, _)   = fr.take(pq3)
+    List(a, b, c) shouldBe List(1, 2, 3)
+
+  it should "report isEmpty correctly" in:
+    val fr  = summon[Frontier[IndexedPrioQueue]]
+    val pq0 = IndexedPrioQueue.empty[Int]
+    fr.isEmpty(pq0) shouldBe true
+    val pq1 = fr.offer(pq0)(1)
+    fr.isEmpty(pq1) shouldBe false
+    val (_, pq2) = fr.take(pq1)
+    fr.isEmpty(pq2) shouldBe true
+
+  it should "deduplicate via offerAll" in:
+    val fr  = summon[Frontier[IndexedPrioQueue]]
+    val pq  = IndexedPrioQueue.empty[Int]
+    val pq1 = fr.offerAll(pq)(List(1, 2, 1, 3))  // 1 appears twice
+    pq1.size shouldBe 3
+
+  // -----------------------------------------------------------------------
+  // TupleVisitedSet — for (E, V) weighted frontiers
+  // -----------------------------------------------------------------------
+
+  "TupleVisitedSet" should "track visited-ness on the vertex component only" in:
+    val vs: VisitedSet[(Int, String)] = summon[VisitedSet[(Int, String)]]
+    vs.isVisited((1, "a")) shouldBe false
+    val vs2 = vs.markVisited((1, "a"))
+    vs2.isVisited((1, "a")) shouldBe true
+    // Same vertex, different cost — still counts as visited
+    vs2.isVisited((99, "a")) shouldBe true
+    // Different vertex — not visited
+    vs2.isVisited((1, "b")) shouldBe false

--- a/src/test/scala/com/phasmidsoftware/visitor/core/PrioQueueSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/visitor/core/PrioQueueSpec.scala
@@ -1,0 +1,130 @@
+package com.phasmidsoftware.visitor.core
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * Tests for [[PrioQueue]] — the priority queue ADT layer.
+  *
+  * PrioQueue delegates structural work to [[BinaryHeap]] and adds the
+  * policy that duplicates are permitted. Tests focus on the ADT contract
+  * (offer/take ordering, duplicates, min vs max) rather than heap mechanics,
+  * which are covered in [[BinaryHeapSpec]].
+  */
+class PrioQueueSpec extends AnyFlatSpec with Matchers:
+
+  // -----------------------------------------------------------------------
+  // Construction
+  // -----------------------------------------------------------------------
+
+  "PrioQueue.empty" should "be empty" in:
+    PrioQueue.empty[Int].isEmpty shouldBe true
+    PrioQueue.empty[Int].size shouldBe 0
+
+  it should "not be empty after offer" in:
+    val pq = PrioQueue.empty[Int].offer(1)
+    pq.isEmpty shouldBe false
+    pq.size shouldBe 1
+
+  // -----------------------------------------------------------------------
+  // Min-priority (default)
+  // -----------------------------------------------------------------------
+
+  "PrioQueue (min)" should "dequeue elements in ascending order" in:
+    val pq = PrioQueue.empty[Int].offer(3).offer(1).offer(2)
+    val (a, pq1) = pq.take
+    val (b, pq2) = pq1.take
+    val (c, _)   = pq2.take
+    List(a, b, c) shouldBe List(1, 2, 3)
+
+  it should "expose the minimum via head without removing it" in:
+    val pq = PrioQueue.empty[Int].offer(3).offer(1).offer(2)
+    pq.head shouldBe 1
+    pq.size shouldBe 3
+
+  it should "dequeue a single element correctly" in:
+    val pq = PrioQueue.empty[Int].offer(7)
+    val (x, pq2) = pq.take
+    x shouldBe 7
+    pq2.isEmpty shouldBe true
+
+  it should "dequeue in ascending order regardless of insertion order" in:
+    val pq = PrioQueue.empty[Int].offer(5).offer(2).offer(8).offer(1).offer(9).offer(3)
+    val result = Iterator.unfold(pq) { q =>
+      if q.isEmpty then None else Some(q.take)
+    }.toList
+    result shouldBe List(1, 2, 3, 5, 8, 9)
+
+  // -----------------------------------------------------------------------
+  // Duplicates
+  // -----------------------------------------------------------------------
+
+  it should "permit duplicate elements" in:
+    val pq = PrioQueue.empty[Int].offer(2).offer(1).offer(2).offer(1)
+    pq.size shouldBe 4
+
+  it should "dequeue duplicates in non-decreasing order" in:
+    val pq = PrioQueue.empty[Int].offer(2).offer(1).offer(2).offer(1)
+    val (a, pq1) = pq.take
+    val (b, pq2) = pq1.take
+    val (c, pq3) = pq2.take
+    val (d, _)   = pq3.take
+    List(a, b, c, d) shouldBe List(1, 1, 2, 2)
+
+  it should "handle all identical elements" in:
+    val pq = PrioQueue.empty[Int].offer(3).offer(3).offer(3)
+    val (a, pq1) = pq.take
+    val (b, pq2) = pq1.take
+    val (c, _)   = pq2.take
+    List(a, b, c) shouldBe List(3, 3, 3)
+
+  // -----------------------------------------------------------------------
+  // Max-priority
+  // -----------------------------------------------------------------------
+
+  "PrioQueue.emptyMax" should "dequeue elements in descending order" in:
+    val pq = PrioQueue.emptyMax[Int].offer(1).offer(3).offer(2)
+    val (a, pq1) = pq.take
+    val (b, pq2) = pq1.take
+    val (c, _)   = pq2.take
+    List(a, b, c) shouldBe List(3, 2, 1)
+
+  it should "expose the maximum via head without removing it" in:
+    val pq = PrioQueue.emptyMax[Int].offer(1).offer(3).offer(2)
+    pq.head shouldBe 3
+
+  it should "dequeue duplicates in non-increasing order" in:
+    val pq = PrioQueue.emptyMax[Int].offer(2).offer(1).offer(2).offer(1)
+    val (a, pq1) = pq.take
+    val (b, pq2) = pq1.take
+    val (c, pq3) = pq2.take
+    val (d, _)   = pq3.take
+    List(a, b, c, d) shouldBe List(2, 2, 1, 1)
+
+  // -----------------------------------------------------------------------
+  // Frontier[PrioQueue] integration
+  // -----------------------------------------------------------------------
+
+  "Frontier[PrioQueue]" should "offer and take in ascending priority order" in:
+    val fr = summon[Frontier[PrioQueue]]
+    val pq = PrioQueue.empty[Int]
+    val pq1 = fr.offer(fr.offer(fr.offer(pq)(3))(1))(2)
+    val (a, pq2) = fr.take(pq1)
+    val (b, pq3) = fr.take(pq2)
+    val (c, _)   = fr.take(pq3)
+    List(a, b, c) shouldBe List(1, 2, 3)
+
+  it should "report isEmpty correctly" in:
+    val fr  = summon[Frontier[PrioQueue]]
+    val pq0 = PrioQueue.empty[Int]
+    fr.isEmpty(pq0) shouldBe true
+    val pq1 = fr.offer(pq0)(1)
+    fr.isEmpty(pq1) shouldBe false
+    val (_, pq2) = fr.take(pq1)
+    fr.isEmpty(pq2) shouldBe true
+
+  it should "permit duplicates via offerAll" in:
+    val fr  = summon[Frontier[PrioQueue]]
+    val pq  = PrioQueue.empty[Int]
+    val pq1 = fr.offerAll(pq)(List(2, 1, 2, 1))
+    pq1.size shouldBe 4

--- a/src/test/scala/com/phasmidsoftware/visitor/core/TranslatedSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/visitor/core/TranslatedSpec.scala
@@ -34,7 +34,7 @@ object TreeFixture:
 // BinaryHeap tests
 // ============================================================
 
-class BinaryHeapSpec extends AnyFlatSpec with Matchers:
+class OldBinaryHeapSpec extends AnyFlatSpec with Matchers:
 
   "BinaryHeap" should "be empty on construction" in :
     BinaryHeap.empty[Int].isEmpty shouldBe true
@@ -79,7 +79,7 @@ class BinaryHeapSpec extends AnyFlatSpec with Matchers:
 // PrioQueue (min and max) tests
 // ============================================================
 
-class PrioQueueSpec extends AnyFlatSpec with Matchers:
+class OldPrioQueueSpec extends AnyFlatSpec with Matchers:
 
   // --- Min ---
 


### PR DESCRIPTION
**feat: V1.3.0** — indexed priority queue hierarchy and CostUpdate typeclass
Introduce a three-type priority queue hierarchy replacing the single
PrioQueue/BinaryHeap pair:

  BinaryHeap[T]       — pure data structure; sift-up/down, insert,
                        removeMin only; no index, no policy
  PrioQueue[T]        — ADT delegating to BinaryHeap; duplicates
                        permitted; Ordering captured at construction
  IndexedPrioQueue[T] — extends PrioQueue contract with Map[T,Int]
                        index; enforces one-entry-per-key; adds
                        decreaseKey and contains

Add CostUpdate[W, F[_]] typeclass with default no-op given, wired into
Traversal.traverse via cu.update after offerAll and at the seed step.

Add TupleVisitedSet[E, V] and given [E, V]: VisitedSet[(E, V)], which
tracks visited-ness on the vertex component V only — required for
correctness when the frontier holds (cost, vertex) tuples.

Add Frontier[IndexedPrioQueue] given alongside Frontier[PrioQueue].

Add Traversal.bestFirstWeighted entry point for Dijkstra/Prim: takes
an IndexedPrioQueue frontier and an explicit CostUpdate instance.

Add 137 tests across BinaryHeapSpec, PrioQueueSpec, IndexedPrioQueueSpec
(including TupleVisitedSet and Frontier integration tests).

**feat: V1.4.0** — add Monoid[A] typeclass
Add Monoid[A] to Behaviours.scala with identity and combine methods,
mirroring Cats Monoid without the Cats dependency.

Provide given instances for Int, Long, Double and Float (additive monoids).

Replaces Numeric[E] as the context bound for weighted graph traversals in
Gryphon — Monoid provides exactly the two operations needed (identity as
seed cost, combine for accumulation) without the full arithmetic baggage
of Numeric.